### PR TITLE
Changed autoload to require()

### DIFF
--- a/lib/tor.rb
+++ b/lib/tor.rb
@@ -17,10 +17,10 @@ end
 ##
 # @see https://www.torproject.org/
 module Tor
-  autoload :Config,     'tor/config'
-  autoload :Controller, 'tor/control'
-  autoload :DNSEL,      'tor/dnsel'
-  autoload :VERSION,    'tor/version'
+  require 'tor/config'
+  require 'tor/control'
+  require 'tor/dnsel'
+  require 'tor/version'
 
   ##
   # Returns `true` if the Tor process is running locally, `false` otherwise.


### PR DESCRIPTION
Changed class imports to use require() instead of autoload. The use of autoload has been discouraged for a while now (especially within Gems).