### PR TITLE
Added "GETINFO config-text" command.

### DIFF
--- a/lib/tor.rb
+++ b/lib/tor.rb
@@ -17,10 +17,10 @@ end
 ##
 # @see https://www.torproject.org/
 module Tor
-  autoload :Config,     'tor/config'
-  autoload :Controller, 'tor/control'
-  autoload :DNSEL,      'tor/dnsel'
-  autoload :VERSION,    'tor/version'
+  require_relative 'tor/config'
+  require_relative 'tor/control'
+  require_relative 'tor/dnsel'
+  require_relative 'tor/version'
 
   ##
   # Returns `true` if the Tor process is running locally, `false` otherwise.

--- a/lib/tor/control.rb
+++ b/lib/tor/control.rb
@@ -237,6 +237,28 @@ module Tor
     end
 
     ##
+    # Returns the current (in-memory) Tor configuration.
+    # Response is terminated with a "."
+    #
+    # @example
+    #   C: GETINFO config-text
+    #   S: 250+config-text=
+    #   S: ControlPort 9051
+    #   S: RunAsDaemon 1
+    #   S: .
+    def config_text
+      send_command(:getinfo, 'config-text')
+      reply = ""
+      read_reply # skip "250+config-text="
+      while line = read_reply
+        break unless line != "."
+        reply.concat(line + "\n")
+      end
+      read_reply # skip "250 OK"
+      return reply
+    end
+
+    ##
     # Send a signal to the server
     #
     # @example


### PR DESCRIPTION
I have added a working implementation of the ```GETINFO config-text``` command. I've tested the implementation with the latest version of Ruby & Tor.

I have also changed the way classes are imported to use ```require_relative()``` instead of ```autoload```. The use of ```autoload``` has been discouraged for quite a while now (especially within Gems).